### PR TITLE
Fixed the issue where all layer purposes are mapped to drawing

### DIFF
--- a/ml2tikz.il
+++ b/ml2tikz.il
@@ -185,7 +185,7 @@
 								(length
 									(dbLayerOr
 										(eval v)->model->oCombinedCellView
-										(car lLayer)
+										lLayer
 										(setof x (eval v)->model->oFlattenCellView~>shapes (equal x~>lpp lLayer))
 									);dbLayerOr
 								);length


### PR DESCRIPTION
dbLayerOr was given only the layer instead of the layer purpose pair. 
This resulted in all layers being on the layer purpose "drawing".